### PR TITLE
 Fix the script for latest Aptoide and Android

### DIFF
--- a/aptoide
+++ b/aptoide
@@ -30,25 +30,103 @@ function main {
 	if [ "$#" -eq 1 ]; then
 		atribut $1
 	else
-		echo "Insert link:"
+		echo "Insert link or package id:"
 		read link
 		atribut $link
 	fi
 }
 
-function atribut {
-	link=$1
+# Try to find the real mobile link by normal aptoide link (https://desired-package-id.en.aptoide.com/?store_name=somestore&app_id=xxxxxxxx)
+function get_real_link_by_normal_link {
+	orig_link=$1
+	curl -o $aptoide_home_dir/.temp $orig_link 2>/dev/null
+	export returncode=$?
+	if ! [ "$returncode" = "0" ]; then
+		exit 0
+	fi
 
-	### Test if we have a valid Aptoide URL ###
-	test_url_regex=$(echo $link | sed -n 's/^\(https:\/\/.*\.store\.aptoide\.com\/\).*$/\1/p')
-	if [[ "$test_url_regex" = "" ]]; then
-		test_url_regex=$(echo $link | sed -n 's/^\(.*\.store\.aptoide\.com\/\).*$/\1/p')
-		if [[ "$test_url_regex" = "" ]]; then
-			echo "This is not a valid Aptoide URL."
+	# find the package in the downloaded given link
+	package_id=$(cat $aptoide_home_dir/.temp | sed -rn 's/.*data-package-id="(([A-Za-z]{1}[A-Za-z\d_]*\.)+[A-Za-z][A-Za-z\d_]*).*/\1/p')
+	if [[ "$package_id" = "" ]]; then
+		exit 0
+	fi
+
+	# get store name / app id from the given link
+	orig_store_name=$(echo $orig_link | sed -rn 's/.*store_name=(.+)&.*/\1/p')
+	orig_app_id=$(echo $orig_link | sed -rn 's/.*app_id=([0-9]+).*/\1/p')
+
+	echo $(get_real_link $package_id $orig_store_name $orig_app_id)
+}
+
+# Try to find the real mobile link by package id (and optional store name + app id)
+function get_real_link {
+	package_id=$1
+
+	orig_store_name=$2
+	orig_app_id=$3
+
+	# Find the app via Aptoide search API
+	curl -k -o $aptoide_home_dir/.temp "https://m.aptoide.com/phpajax/get_search.php?searchtxt=$package_id&type=apps" 2>/dev/null
+	export returncode=$?
+	if ! [ "$returncode" = "0" ]; then
+		exit 0
+	fi
+
+	# Get the link parts
+	real_link_parts=($(cat $aptoide_home_dir/.temp | sed -rn 's/.*m.(.*).store.aptoide.com\\\/app\\\/market\\\/'$package_id'\\\/([0-9]*)\\\/([0-9]*).*/\1 \2 \3/p'))
+	if [ -z "$real_link_parts" ]; then
+		exit 0
+	fi
+
+	if [ "$orig_store_name" = "" ]; then
+		# We want to download the latest version of the app, build the link url
+		real_link=$(cat $aptoide_home_dir/.temp | sed -rn 's/.*(m.'${real_link_parts[0]}'.store.aptoide.com\\\/app\\\/market\\\/'$package_id'\\\/[0-9]*\\\/[0-9]*\\\/[^\]*).*/\1/p' | sed 's/\\\//\//g')
+
+	else
+		# We want to download a specific version from a specific Store
+
+		# Get all versions of the app
+		curl -k -o $aptoide_home_dir/.temp -H "User-Agent: AptoideLite/44" "https://m.aptoide.com/list/versions/$package_id/${real_link_parts[1]}" 2>/dev/null
+		export returncode=$?
+		if ! [ "$returncode" = "0" ]; then
 			exit 0
-		else
-			link="https://$link"
 		fi
+
+		# find the link of the version we are looking fo
+		real_link=($(cat $aptoide_home_dir/.temp | sed -rn 's/.*(m.'$orig_store_name'.store.aptoide.com\/app\/market\/'$package_id'\/[0-9]*\/'$orig_app_id'\/[^"]*).*/\1/p'))
+		real_link=${real_link[0]}
+	fi
+
+	rm $aptoide_home_dir/.temp
+	echo "https://$real_link"
+}
+
+function atribut {
+	if echo $1 | grep -Eq '^(([A-Za-z]{1}[A-Za-z\d_]*\.)+[A-Za-z][A-Za-z\d_]*)$'; then
+		# We got a package id as parameter
+		link=$(get_real_link $1)
+	else
+		link=$1
+
+		### Always use https ###
+		link=$(echo $link | sed 's/http:\/\//https:\/\//g')
+
+		### Test if we have a valid Aptoide URL ###
+		test_url_regex=$(echo $link | sed -n 's/^\(https:\/\/.*\.store\.aptoide\.com\/\).*$/\1/p')
+		if [[ "$test_url_regex" = "" ]]; then
+			test_url_regex=$(echo $link | sed -n 's/^\(https:\/\/photoscan-by-google-photos\.[a-z]\{2,3\}\.aptoide\.com\).*$/\1/p')
+			if [[ "$test_url_regex" = "" ]]; then
+				echo "This is not a valid Aptoide URL."
+				exit 0
+			else
+				link=$(get_real_link_by_normal_link $link)
+			fi
+		fi
+	fi
+
+	if [[ "$link" = "" ]]; then
+		echo "Download site not found."
+		exit 0
 	fi
 
 	### We change the normal HTTP link in the HTTP link used for mobile phones ###
@@ -68,7 +146,7 @@ function atribut {
 
 	### download the html of the input url ###
 	echo "Downloading the HTML file to extract information..."
-	wget --no-check-certificate -q --user-agent="" $link_http -O $aptoide_home_dir/.$apk_package_name
+	curl -k -o $aptoide_home_dir/.$apk_package_name -H "User-Agent: AptoideLite/44" $link_http 2>/dev/null
 
 	export returncode=$?
 	if ! [ "$returncode" = "0" ]; then
@@ -118,7 +196,7 @@ function atribut {
 	##############################################
 	### Save the APK in the download directory ###
 	echo "Downloading APK file..."
-	wget -c --user-agent="" $apk_link -O "$aptoide_home_dir/$apk_package_name $version_number.apk"
+	curl -C - -H "User-Agent: AptoideLite/44" -o "$aptoide_home_dir/$apk_package_name $version_number.apk" $apk_link
 
 	export returncode=$?
 	if [ "$returncode" = "0" ]; then

--- a/aptoide
+++ b/aptoide
@@ -1,45 +1,134 @@
 #!/bin/bash
-### Aptoide Downloader v2
 
 echo -e "\e[1m\e[93mAptoide Downloader\e[0m
-\e[1mCopyright (C) 2012-2019 Cristian Stefanescu\e[0m
+\e[1mCopyright (C) 2012-2015 Cristian Stefanescu\e[0m
 This program comes with ABSOLUTELY NO WARRANTY;
 This is free software, and you are welcome to redistribute it
 under certain conditions;  for details see LICENCE
 or visit http://www.gnu.org/licenses/
+
 \e[1mContributors:
-https://github.com/bastei
-https://github.com/mfonville\e[0m"
+	https://github.com/bastei
+	https://github.com/mfonville\e[0m"
+
+### Main function. You can start the download using the link as a argument, ###
+### or read the link from stdin after running the script. 					###
+function main {
+	### We create a folder in which Aptoide will download the apk 	###
+	### and we save the name in a variable 							###
+	if [ -w "/storage/sdcard0" ]; then
+		aptoide_home_dir="/storage/sdcard0/Download/aptoide"
+	elif [ -w "$(xdg-user-dir DOWNLOAD)" ]; then
+		aptoide_home_dir="$(xdg-user-dir DOWNLOAD)/aptoide"
+	else
+		aptoide_home_dir="$HOME/aptoide"
+	fi
+
+	mkdir -p $aptoide_home_dir
 
 
-### some variables we somehow need
-### get page as html, use either arg1 or read from stdin
-if [ "$#" -eq 1 ]; then
-    URL=$1
-else
-    echo -e "\n\nInsert Aptoide URL:"
-    read link
-    URL=$link
-fi
-### Use the name in the URL to get the filename
-APK=$( echo $URL | sed 's,.*://,,g;s,..[a-zA-Z].aptoide.com.,,' )
-### Use a temporary file
-TEMP_PAGE=$( mktemp )
+	if [ "$#" -eq 1 ]; then
+		atribut $1
+	else
+		echo "Insert link:"
+		read link
+		atribut $link
+	fi
+}
 
-### Download the HTML source page
-wget -q $URL -O $TEMP_PAGE
+function atribut {
+	link=$1
 
-### Extract the apk link from the page
-LINK=$(grep data-mobile-download $TEMP_PAGE  | sed 's/.*="//g;s/.$//g')
+	### Test if we have a valid Aptoide URL ###
+	test_url_regex=$(echo $link | sed -n 's/^\(https:\/\/.*\.store\.aptoide\.com\/\).*$/\1/p')
+	if [[ "$test_url_regex" = "" ]]; then
+		test_url_regex=$(echo $link | sed -n 's/^\(.*\.store\.aptoide\.com\/\).*$/\1/p')
+		if [[ "$test_url_regex" = "" ]]; then
+			echo "This is not a valid Aptoide URL."
+			exit 0
+		else
+			link="https://$link"
+		fi
+	fi
 
-### Download the final link
-### aptoide.sh will download the apk in ~/Downloads or ~ if ~/Downloads is not accesible
-if [ -w "$( xdg-user-dir DOWNLOAD )" ]; then
-    aptoide_home_dir="$( xdg-user-dir DOWNLOAD )"
-else
-    aptoide_home_dir="$HOME"
-fi
-wget -q --show-progress $LINK -O $aptoide_home_dir/$APK.apk
+	### We change the normal HTTP link in the HTTP link used for mobile phones ###
+	mobile=$(echo 'https://m.')
+	test_link=$(echo $link | grep -o 'https://m.')
+	if [ "$mobile" == "$test_link" ]; then
+		link_http=$link
+		else
+		link_http=$(echo $link | sed 's/https:\/\//https:\/\/m./g')
+	fi
 
-### Cleanup the temporary file
-rm $TEMP_PAGE
+	### get the relevant parts of the HTTP link 						###
+	### the first part is the package name								###
+	### the other two are numbers we need in the final download link 	###
+	link_parts=($(echo $link_http | sed -n 's/^https:\/\/m\.\(.*\)\.store\.aptoide\.com\/.*\/\([a-zA-Z0-9\._\-]*\)\/\([0-9]*\)\/\([0-9]*\)\/.*$/\1 \2 \3 \4/p'))
+	apk_package_name=${link_parts[1]}
+
+	### download the html of the input url ###
+	echo "Downloading the HTML file to extract information..."
+	wget --no-check-certificate -q --user-agent="" $link_http -O $aptoide_home_dir/.$apk_package_name
+
+	export returncode=$?
+	if ! [ "$returncode" = "0" ]; then
+		echo -e "\nSorry, something went wrong...\n"
+		exit 0
+	fi
+
+	### Check the trust level of the app ###
+	trust_level=$(cat $aptoide_home_dir/.$apk_package_name | sed -n 's/.*app_install \([a-z]*\).*/\1/p')
+	case $trust_level in
+		"trusted" ) echo "The APK is \"trusted\"".
+		;;
+		"unknown" ) echo "Be careful! Trust level of the APK is \"unknown\""!
+		;;
+		"warn" | "warning" )
+			echo -e "\nWARNING: Trust level of the APK is \"warning\" - the app is NOT trusted!"
+			echo "If you are shure you still want to download, enter \"yes\""
+			read download_answer
+			if ! [ "$download_answer" == "yes" ]; then
+				echo "Download cancelled"
+				exit 0;
+			fi
+		;;
+		*) echo "Trust level can't be detected."
+		;;
+	esac
+
+	### Get the version number of the App ###
+	version_number=$(cat $aptoide_home_dir/.$apk_package_name | sed -n 's/.*Ver.*:\ <\/b>\(.*\) |.*/\1/p')
+
+	################################################
+	### Get the parts for the final download url ###
+
+	domain="http://pool.apk.aptoide.com"
+
+	### Convert the package name, preplace "." and 	###
+	### "_" with "-" and convert to lower space 	###
+	link_apk_package_name=$(echo $apk_package_name | sed 's/\./\-/g' | sed 's/\_/\-/g' | awk '{print tolower($0)}')
+
+	### MD5 number, taken from the loaded html file and ###
+	### stripped from the line "<div><strong>MD5:</strong> #32-md5-digits#</div>" ###
+	link_md5=$(cat $aptoide_home_dir/.$apk_package_name | sed -n 's/.*MD5:.* \([0-9a-z]\{32\}\).*/\1/p')
+
+	### The final APK download url
+	apk_link="$domain/${link_parts[0]}/$link_apk_package_name-${link_parts[2]}-${link_parts[3]}-$link_md5.apk"
+
+	##############################################
+	### Save the APK in the download directory ###
+	echo "Downloading APK file..."
+	wget -c --user-agent="" $apk_link -O "$aptoide_home_dir/$apk_package_name $version_number.apk"
+
+	export returncode=$?
+	if [ "$returncode" = "0" ]; then
+	   echo -e "\nFile saved as \"$apk_package_name $version_number.apk\" in \"$aptoide_home_dir\"\n"
+	else
+		echo -e "\nSorry, something went wrong...\n"
+	fi
+
+	### Cleanup ###
+	rm $aptoide_home_dir/.$apk_package_name 2>&1
+}
+
+main $@;


### PR DESCRIPTION
I reverted the latest refactoring as the script was basically still working. Fixes #7. Added some helper functions anyway - now you can download an app by using either an Aptoide-URL or the package id of the desired App.